### PR TITLE
feat: Support `transit_encryption_mode` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,14 +284,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -380,6 +380,7 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC Subnet IDs for the Elasticache subnet group | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Enable encryption in-transit. Supported only with Memcached versions `1.6.12` and later, running in a VPC | `bool` | `true` | no |
+| <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are preferred and required | `string` | `null` | no |
 | <a name="input_user_group_ids"></a> [user\_group\_ids](#input\_user\_group\_ids) | User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid | `list(string)` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Identifier of the VPC where the security group will be created | `string` | `null` | no |
 

--- a/examples/memcached-cluster/README.md
+++ b/examples/memcached-cluster/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 
 ## Modules
 

--- a/examples/memcached-cluster/versions.tf
+++ b/examples/memcached-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/examples/redis-cluster-mode/README.md
+++ b/examples/redis-cluster-mode/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 
 ## Modules
 

--- a/examples/redis-cluster-mode/versions.tf
+++ b/examples/redis-cluster-mode/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/examples/redis-cluster/README.md
+++ b/examples/redis-cluster/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 
 ## Modules
 

--- a/examples/redis-cluster/versions.tf
+++ b/examples/redis-cluster/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/examples/redis-global-replication-group/README.md
+++ b/examples/redis-global-replication-group/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
-| <a name="provider_aws.euwest1"></a> [aws.euwest1](#provider\_aws.euwest1) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
+| <a name="provider_aws.euwest1"></a> [aws.euwest1](#provider\_aws.euwest1) | >= 5.47 |
 
 ## Modules
 

--- a/examples/redis-global-replication-group/versions.tf
+++ b/examples/redis-global-replication-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/examples/redis-replication-group/README.md
+++ b/examples/redis-replication-group/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 
 ## Modules
 

--- a/examples/redis-replication-group/versions.tf
+++ b/examples/redis-replication-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/examples/serverless-cache/versions.tf
+++ b/examples/serverless-cache/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -115,6 +115,7 @@ resource "aws_elasticache_replication_group" "this" {
   snapshot_window             = var.snapshot_window
   subnet_group_name           = local.subnet_group_name
   transit_encryption_enabled  = var.transit_encryption_enabled
+  transit_encryption_mode     = var.transit_encryption_mode
   user_group_ids              = var.user_group_ids
 
   tags = local.tags
@@ -214,6 +215,8 @@ resource "aws_cloudwatch_log_group" "this" {
   name              = "/aws/elasticache/${try(each.value.cloudwatch_log_group_name, coalesce(var.cluster_id, var.replication_group_id), "")}"
   retention_in_days = try(each.value.cloudwatch_log_group_retention_in_days, 14)
   kms_key_id        = try(each.value.cloudwatch_log_group_kms_key_id, null)
+  skip_destroy      = try(each.value.cloudwatch_log_group_skip_destroy, null)
+  log_group_class   = try(each.value.cloudwatch_log_group_class, null)
 
   tags = merge(local.tags, try(each.value.tags, {}))
 }

--- a/modules/serverless-cache/README.md
+++ b/modules/serverless-cache/README.md
@@ -60,13 +60,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 
 ## Modules
 

--- a/modules/serverless-cache/versions.tf
+++ b/modules/serverless-cache/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/modules/user-group/README.md
+++ b/modules/user-group/README.md
@@ -66,13 +66,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
 
 ## Modules
 

--- a/modules/user-group/versions.tf
+++ b/modules/user-group/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -181,6 +181,12 @@ variable "transit_encryption_enabled" {
   default     = true
 }
 
+variable "transit_encryption_mode" {
+  description = "A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are preferred and required"
+  type        = string
+  default     = null
+}
+
 ################################################################################
 # Replication Group
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.46"
+      version = ">= 5.47"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description
Support `transit_encryption_mode` for replication groups. 
Added support for `skip_destroy` and `log_group_class` for `aws_cloudwatch_log_group` as well. 

Did not add `transit_encryption_mode` for global replication groups since primary members cannot be replication group with transit-encryption-mode preferred.

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/issues/30403

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
