### PR TITLE
fix: Support for optional creation of log delivery configuration for Elasticache

### DIFF
--- a/examples/redis-cluster/README.md
+++ b/examples/redis-cluster/README.md
@@ -34,6 +34,7 @@ Note that this example may create resources which will incur monetary charges on
 |------|--------|---------|
 | <a name="module_elasticache"></a> [elasticache](#module\_elasticache) | ../../ | n/a |
 | <a name="module_elasticache_disabled"></a> [elasticache\_disabled](#module\_elasticache\_disabled) | ../.. | n/a |
+| <a name="module_elasticache_logging_disabled"></a> [elasticache\_logging\_disabled](#module\_elasticache\_logging\_disabled) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources

--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -66,6 +66,58 @@ module "elasticache" {
   tags = local.tags
 }
 
+module "elasticache_logging_disabled" {
+  source = "../../"
+
+  cluster_id               = "${local.name}-logging-disabled"
+  create_cluster           = true
+  create_replication_group = false
+
+  engine_version = "7.1"
+  node_type      = "cache.t4g.small"
+
+  maintenance_window = "sun:05:00-sun:09:00"
+  apply_immediately  = true
+
+  # Security Group
+  vpc_id = module.vpc.vpc_id
+  security_group_rules = {
+    ingress_vpc = {
+      # Default type is `ingress`
+      # Default port is based on the default engine port
+      description = "VPC traffic"
+      cidr_ipv4   = module.vpc.vpc_cidr_block
+    }
+  }
+
+  # Subnet Group
+  subnet_group_name        = local.name
+  subnet_group_description = "${title(local.name)} subnet group"
+  subnet_ids               = module.vpc.private_subnets
+
+  # Parameter Group
+  create_parameter_group      = true
+  parameter_group_name        = local.name
+  parameter_group_family      = "redis7"
+  parameter_group_description = "${title(local.name)} parameter group"
+  parameters = [
+    {
+      name  = "latency-tracking"
+      value = "yes"
+    }
+  ]
+
+  log_delivery_configuration = {
+    "slow-log" = {
+      create_cloudwatch_log_group = false,
+      destination                 = ""
+      destination_type            = "cloudwatch-logs",
+      log_format                  = "json",
+    }
+  }
+  tags = local.tags
+}
+
 module "elasticache_disabled" {
   source = "../.."
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_elasticache_cluster" "this" {
   ip_discovery               = var.ip_discovery
 
   dynamic "log_delivery_configuration" {
-    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine != "memcached" }
+    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine != "memcached" && try(v.create_cloudwatch_log_group, true) }
 
     content {
       destination      = try(log_delivery_configuration.value.create_cloudwatch_log_group, true) && log_delivery_configuration.value.destination_type == "cloudwatch-logs" ? aws_cloudwatch_log_group.this[log_delivery_configuration.key].name : log_delivery_configuration.value.destination
@@ -85,7 +85,7 @@ resource "aws_elasticache_replication_group" "this" {
   kms_key_id                  = var.at_rest_encryption_enabled ? var.kms_key_arn : null
 
   dynamic "log_delivery_configuration" {
-    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine == "redis" }
+    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine == "redis" && try(v.create_cloudwatch_log_group, true) }
 
     content {
       destination      = try(log_delivery_configuration.value.create_cloudwatch_log_group, true) && log_delivery_configuration.value.destination_type == "cloudwatch-logs" ? aws_cloudwatch_log_group.this[log_delivery_configuration.key].name : log_delivery_configuration.value.destination
@@ -162,7 +162,7 @@ resource "aws_elasticache_replication_group" "global" {
   kms_key_id                  = var.at_rest_encryption_enabled ? var.kms_key_arn : null
 
   dynamic "log_delivery_configuration" {
-    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine != "memcached" }
+    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine != "memcached" && try(v.create_cloudwatch_log_group, true) }
 
     content {
       destination      = try(log_delivery_configuration.value.create_cloudwatch_log_group, true) && log_delivery_configuration.value.destination_type == "cloudwatch-logs" ? aws_cloudwatch_log_group.this[log_delivery_configuration.key].name : log_delivery_configuration.value.destination


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
Making sure that `log_delivery_configuration` is not created when `create_cloudwatch_log_group`  is provided as false. We are skipping the creation of AWS CloudWatch log group when `create_cloudwatch_log_group` under `log_delivery_configuration` variable is false but we are not checking this value while setting up the argument `log_delivery_configuration` for resources `aws_elasticache_cluster`, `aws_elasticache_replication_group` and `aws_elasticache_replication_group`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While creating Redis or Memcached, we do not need to configure log delivery configuration every time. We can see from Terraform documentation that this argument is optional and we should be able to skip the association of log group configuration with our Redis or Memcached.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes are expected because `try` function is used to check for the value `create_cloudwatch_log_group` if it's not passed a default `true` is provided.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

<img width="1039" alt="image" src="https://github.com/terraform-aws-modules/terraform-aws-elasticache/assets/115683842/a42d8946-1792-4c40-9dc7-0a20413e3682">
