### PR TITLE
fix: Argument `replication_group_id` conflicts with `engine` and `log_delivery_configuration`

### DIFF
--- a/examples/redis-replication-group-with-cluster-replica/README.md
+++ b/examples/redis-replication-group-with-cluster-replica/README.md
@@ -1,0 +1,78 @@
+# ElastiCache example for Redis replication group with cluster replica
+
+Configuration in this directory creates set of ElastiCaChe resources including replication group, subnet group, parameter group, and ElastiCache cluster replica.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.47 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.47 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cluster_replica"></a> [cluster\_replica](#module\_cluster\_replica) | ../../ | n/a |
+| <a name="module_elasticache"></a> [elasticache](#module\_elasticache) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cloudwatch_log_group_arn"></a> [cloudwatch\_log\_group\_arn](#output\_cloudwatch\_log\_group\_arn) | Arn of cloudwatch log group created |
+| <a name="output_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#output\_cloudwatch\_log\_group\_name) | Name of cloudwatch log group created |
+| <a name="output_cluster_address"></a> [cluster\_address](#output\_cluster\_address) | (Memcached only) DNS name of the cache cluster without the port appended |
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The ARN of the ElastiCache Cluster |
+| <a name="output_cluster_cache_nodes"></a> [cluster\_cache\_nodes](#output\_cluster\_cache\_nodes) | List of node objects including `id`, `address`, `port` and `availability_zone` |
+| <a name="output_cluster_configuration_endpoint"></a> [cluster\_configuration\_endpoint](#output\_cluster\_configuration\_endpoint) | (Memcached only) Configuration endpoint to allow host discovery |
+| <a name="output_cluster_engine_version_actual"></a> [cluster\_engine\_version\_actual](#output\_cluster\_engine\_version\_actual) | Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine |
+| <a name="output_global_replication_group_arn"></a> [global\_replication\_group\_arn](#output\_global\_replication\_group\_arn) | ARN of the created ElastiCache Global Replication Group |
+| <a name="output_global_replication_group_engine_version_actual"></a> [global\_replication\_group\_engine\_version\_actual](#output\_global\_replication\_group\_engine\_version\_actual) | The full version number of the cache engine running on the members of this global replication group |
+| <a name="output_global_replication_group_id"></a> [global\_replication\_group\_id](#output\_global\_replication\_group\_id) | ID of the ElastiCache Global Replication Group |
+| <a name="output_global_replication_group_node_groups"></a> [global\_replication\_group\_node\_groups](#output\_global\_replication\_group\_node\_groups) | Set of node groups (shards) on the global replication group |
+| <a name="output_parameter_group_arn"></a> [parameter\_group\_arn](#output\_parameter\_group\_arn) | The AWS ARN associated with the parameter group |
+| <a name="output_parameter_group_id"></a> [parameter\_group\_id](#output\_parameter\_group\_id) | The ElastiCache parameter group name |
+| <a name="output_replication_group_arn"></a> [replication\_group\_arn](#output\_replication\_group\_arn) | ARN of the created ElastiCache Replication Group |
+| <a name="output_replication_group_coniguration_endpoint_address"></a> [replication\_group\_coniguration\_endpoint\_address](#output\_replication\_group\_coniguration\_endpoint\_address) | Address of the replication group configuration endpoint when cluster mode is enabled |
+| <a name="output_replication_group_engine_version_actual"></a> [replication\_group\_engine\_version\_actual](#output\_replication\_group\_engine\_version\_actual) | Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine |
+| <a name="output_replication_group_id"></a> [replication\_group\_id](#output\_replication\_group\_id) | ID of the ElastiCache Replication Group |
+| <a name="output_replication_group_member_clusters"></a> [replication\_group\_member\_clusters](#output\_replication\_group\_member\_clusters) | Identifiers of all the nodes that are part of this replication group |
+| <a name="output_replication_group_primary_endpoint_address"></a> [replication\_group\_primary\_endpoint\_address](#output\_replication\_group\_primary\_endpoint\_address) | Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled |
+| <a name="output_replication_group_reader_endpoint_address"></a> [replication\_group\_reader\_endpoint\_address](#output\_replication\_group\_reader\_endpoint\_address) | Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled |
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
+| <a name="output_subnet_group_name"></a> [subnet\_group\_name](#output\_subnet\_group\_name) | The ElastiCache subnet group name |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-elasticache/blob/master/LICENSE).

--- a/examples/redis-replication-group-with-cluster-replica/README.md
+++ b/examples/redis-replication-group-with-cluster-replica/README.md
@@ -1,6 +1,6 @@
 # ElastiCache example for Redis replication group with cluster replica
 
-Configuration in this directory creates set of ElastiCaChe resources including replication group, subnet group, parameter group, and ElastiCache cluster replica.
+Configuration in this directory creates a replication group with a cluster replica both in a single module and separate modules as well to show adding a cluster replica to an existing replication group.
 
 ## Usage
 
@@ -33,7 +33,8 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cluster_replica"></a> [cluster\_replica](#module\_cluster\_replica) | ../../ | n/a |
-| <a name="module_elasticache"></a> [elasticache](#module\_elasticache) | ../../ | n/a |
+| <a name="module_replication_group"></a> [replication\_group](#module\_replication\_group) | ../../ | n/a |
+| <a name="module_replication_group_with_cluster_replica"></a> [replication\_group\_with\_cluster\_replica](#module\_replication\_group\_with\_cluster\_replica) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources

--- a/examples/redis-replication-group-with-cluster-replica/main.tf
+++ b/examples/redis-replication-group-with-cluster-replica/main.tf
@@ -1,0 +1,100 @@
+provider "aws" {
+  region = local.region
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  region = "eu-west-1"
+  name   = "ex-${basename(path.cwd)}"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  tags = {
+    Name       = local.name
+    Example    = local.name
+    Repository = "https://github.com/terraform-aws-modules/terraform-aws-elasticache"
+  }
+}
+
+################################################################################
+# ElastiCache Module
+################################################################################
+
+module "elasticache" {
+  source = "../../"
+
+  replication_group_id = "ex-replication-group"
+
+  engine_version = "7.1"
+  node_type      = "cache.t4g.small"
+
+  transit_encryption_enabled = true
+  auth_token                 = "PickSomethingMoreSecure123!"
+  maintenance_window         = "sun:05:00-sun:09:00"
+  apply_immediately          = true
+
+  # Security Group
+  vpc_id = module.vpc.vpc_id
+  security_group_rules = {
+    ingress_vpc = {
+      # Default type is `ingress`
+      # Default port is based on the default engine port
+      description = "VPC traffic"
+      cidr_ipv4   = module.vpc.vpc_cidr_block
+    }
+  }
+
+  # Subnet Group
+  subnet_group_name        = local.name
+  subnet_group_description = "${title(local.name)} subnet group"
+  subnet_ids               = module.vpc.private_subnets
+
+  # Parameter Group
+  create_parameter_group      = true
+  parameter_group_name        = local.name
+  parameter_group_family      = "redis7"
+  parameter_group_description = "${title(local.name)} parameter group"
+  parameters = [
+    {
+      name  = "latency-tracking"
+      value = "yes"
+    }
+  ]
+
+  tags = local.tags
+}
+
+module "cluster_replica" {
+  source = "../../"
+
+  cluster_id               = "ex-cluster-replica"
+  create_cluster           = true
+  cluster_mode_enabled     = false
+  replication_group_id     = module.elasticache.replication_group_id
+  create_replication_group = false
+  create_subnet_group      = false
+
+  log_delivery_configuration = {
+    create_cloudwatch_log_group = false
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs             = local.azs
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 10)]
+
+  tags = local.tags
+}

--- a/examples/redis-replication-group-with-cluster-replica/outputs.tf
+++ b/examples/redis-replication-group-with-cluster-replica/outputs.tf
@@ -4,27 +4,27 @@
 
 output "cluster_arn" {
   description = "The ARN of the ElastiCache Cluster"
-  value       = module.elasticache.cluster_arn
+  value       = module.replication_group_with_cluster_replica.cluster_arn
 }
 
 output "cluster_engine_version_actual" {
   description = "Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine"
-  value       = module.elasticache.cluster_engine_version_actual
+  value       = module.replication_group_with_cluster_replica.cluster_engine_version_actual
 }
 
 output "cluster_cache_nodes" {
   description = "List of node objects including `id`, `address`, `port` and `availability_zone`"
-  value       = module.elasticache.cluster_cache_nodes
+  value       = module.replication_group_with_cluster_replica.cluster_cache_nodes
 }
 
 output "cluster_address" {
   description = "(Memcached only) DNS name of the cache cluster without the port appended"
-  value       = module.elasticache.cluster_address
+  value       = module.replication_group_with_cluster_replica.cluster_address
 }
 
 output "cluster_configuration_endpoint" {
   description = "(Memcached only) Configuration endpoint to allow host discovery"
-  value       = module.elasticache.cluster_configuration_endpoint
+  value       = module.replication_group_with_cluster_replica.cluster_configuration_endpoint
 }
 
 ################################################################################
@@ -33,37 +33,37 @@ output "cluster_configuration_endpoint" {
 
 output "replication_group_arn" {
   description = "ARN of the created ElastiCache Replication Group"
-  value       = module.elasticache.replication_group_arn
+  value       = module.replication_group_with_cluster_replica.replication_group_arn
 }
 
 output "replication_group_engine_version_actual" {
   description = "Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine"
-  value       = module.elasticache.replication_group_engine_version_actual
+  value       = module.replication_group_with_cluster_replica.replication_group_engine_version_actual
 }
 
 output "replication_group_coniguration_endpoint_address" {
   description = "Address of the replication group configuration endpoint when cluster mode is enabled"
-  value       = module.elasticache.replication_group_coniguration_endpoint_address
+  value       = module.replication_group_with_cluster_replica.replication_group_coniguration_endpoint_address
 }
 
 output "replication_group_id" {
   description = "ID of the ElastiCache Replication Group"
-  value       = module.elasticache.replication_group_id
+  value       = module.replication_group_with_cluster_replica.replication_group_id
 }
 
 output "replication_group_member_clusters" {
   description = "Identifiers of all the nodes that are part of this replication group"
-  value       = module.elasticache.replication_group_member_clusters
+  value       = module.replication_group_with_cluster_replica.replication_group_member_clusters
 }
 
 output "replication_group_primary_endpoint_address" {
   description = "Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled"
-  value       = module.elasticache.replication_group_primary_endpoint_address
+  value       = module.replication_group_with_cluster_replica.replication_group_primary_endpoint_address
 }
 
 output "replication_group_reader_endpoint_address" {
   description = "Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled"
-  value       = module.elasticache.replication_group_reader_endpoint_address
+  value       = module.replication_group_with_cluster_replica.replication_group_reader_endpoint_address
 }
 
 ################################################################################
@@ -72,22 +72,22 @@ output "replication_group_reader_endpoint_address" {
 
 output "global_replication_group_id" {
   description = "ID of the ElastiCache Global Replication Group"
-  value       = module.elasticache.global_replication_group_id
+  value       = module.replication_group_with_cluster_replica.global_replication_group_id
 }
 
 output "global_replication_group_arn" {
   description = "ARN of the created ElastiCache Global Replication Group"
-  value       = module.elasticache.global_replication_group_arn
+  value       = module.replication_group_with_cluster_replica.global_replication_group_arn
 }
 
 output "global_replication_group_engine_version_actual" {
   description = "The full version number of the cache engine running on the members of this global replication group"
-  value       = module.elasticache.global_replication_group_engine_version_actual
+  value       = module.replication_group_with_cluster_replica.global_replication_group_engine_version_actual
 }
 
 output "global_replication_group_node_groups" {
   description = "Set of node groups (shards) on the global replication group"
-  value       = module.elasticache.global_replication_group_node_groups
+  value       = module.replication_group_with_cluster_replica.global_replication_group_node_groups
 }
 
 ################################################################################
@@ -96,12 +96,12 @@ output "global_replication_group_node_groups" {
 
 output "cloudwatch_log_group_name" {
   description = "Name of cloudwatch log group created"
-  value       = module.elasticache.cloudwatch_log_group_name
+  value       = module.replication_group_with_cluster_replica.cloudwatch_log_group_name
 }
 
 output "cloudwatch_log_group_arn" {
   description = "Arn of cloudwatch log group created"
-  value       = module.elasticache.cloudwatch_log_group_arn
+  value       = module.replication_group_with_cluster_replica.cloudwatch_log_group_arn
 }
 
 ################################################################################
@@ -110,12 +110,12 @@ output "cloudwatch_log_group_arn" {
 
 output "parameter_group_arn" {
   description = "The AWS ARN associated with the parameter group"
-  value       = module.elasticache.parameter_group_arn
+  value       = module.replication_group_with_cluster_replica.parameter_group_arn
 }
 
 output "parameter_group_id" {
   description = "The ElastiCache parameter group name"
-  value       = module.elasticache.parameter_group_id
+  value       = module.replication_group_with_cluster_replica.parameter_group_id
 }
 
 ################################################################################
@@ -124,7 +124,7 @@ output "parameter_group_id" {
 
 output "subnet_group_name" {
   description = "The ElastiCache subnet group name"
-  value       = module.elasticache.subnet_group_name
+  value       = module.replication_group_with_cluster_replica.subnet_group_name
 }
 
 ################################################################################
@@ -133,10 +133,10 @@ output "subnet_group_name" {
 
 output "security_group_arn" {
   description = "Amazon Resource Name (ARN) of the security group"
-  value       = module.elasticache.security_group_arn
+  value       = module.replication_group_with_cluster_replica.security_group_arn
 }
 
 output "security_group_id" {
   description = "ID of the security group"
-  value       = module.elasticache.security_group_id
+  value       = module.replication_group_with_cluster_replica.security_group_id
 }

--- a/examples/redis-replication-group-with-cluster-replica/outputs.tf
+++ b/examples/redis-replication-group-with-cluster-replica/outputs.tf
@@ -1,0 +1,142 @@
+################################################################################
+# Cluster
+################################################################################
+
+output "cluster_arn" {
+  description = "The ARN of the ElastiCache Cluster"
+  value       = module.elasticache.cluster_arn
+}
+
+output "cluster_engine_version_actual" {
+  description = "Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine"
+  value       = module.elasticache.cluster_engine_version_actual
+}
+
+output "cluster_cache_nodes" {
+  description = "List of node objects including `id`, `address`, `port` and `availability_zone`"
+  value       = module.elasticache.cluster_cache_nodes
+}
+
+output "cluster_address" {
+  description = "(Memcached only) DNS name of the cache cluster without the port appended"
+  value       = module.elasticache.cluster_address
+}
+
+output "cluster_configuration_endpoint" {
+  description = "(Memcached only) Configuration endpoint to allow host discovery"
+  value       = module.elasticache.cluster_configuration_endpoint
+}
+
+################################################################################
+# Replication Group
+################################################################################
+
+output "replication_group_arn" {
+  description = "ARN of the created ElastiCache Replication Group"
+  value       = module.elasticache.replication_group_arn
+}
+
+output "replication_group_engine_version_actual" {
+  description = "Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine"
+  value       = module.elasticache.replication_group_engine_version_actual
+}
+
+output "replication_group_coniguration_endpoint_address" {
+  description = "Address of the replication group configuration endpoint when cluster mode is enabled"
+  value       = module.elasticache.replication_group_coniguration_endpoint_address
+}
+
+output "replication_group_id" {
+  description = "ID of the ElastiCache Replication Group"
+  value       = module.elasticache.replication_group_id
+}
+
+output "replication_group_member_clusters" {
+  description = "Identifiers of all the nodes that are part of this replication group"
+  value       = module.elasticache.replication_group_member_clusters
+}
+
+output "replication_group_primary_endpoint_address" {
+  description = "Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled"
+  value       = module.elasticache.replication_group_primary_endpoint_address
+}
+
+output "replication_group_reader_endpoint_address" {
+  description = "Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled"
+  value       = module.elasticache.replication_group_reader_endpoint_address
+}
+
+################################################################################
+# Global Replication Group
+################################################################################
+
+output "global_replication_group_id" {
+  description = "ID of the ElastiCache Global Replication Group"
+  value       = module.elasticache.global_replication_group_id
+}
+
+output "global_replication_group_arn" {
+  description = "ARN of the created ElastiCache Global Replication Group"
+  value       = module.elasticache.global_replication_group_arn
+}
+
+output "global_replication_group_engine_version_actual" {
+  description = "The full version number of the cache engine running on the members of this global replication group"
+  value       = module.elasticache.global_replication_group_engine_version_actual
+}
+
+output "global_replication_group_node_groups" {
+  description = "Set of node groups (shards) on the global replication group"
+  value       = module.elasticache.global_replication_group_node_groups
+}
+
+################################################################################
+# CloudWatch Log Group
+################################################################################
+
+output "cloudwatch_log_group_name" {
+  description = "Name of cloudwatch log group created"
+  value       = module.elasticache.cloudwatch_log_group_name
+}
+
+output "cloudwatch_log_group_arn" {
+  description = "Arn of cloudwatch log group created"
+  value       = module.elasticache.cloudwatch_log_group_arn
+}
+
+################################################################################
+# Parameter Group
+################################################################################
+
+output "parameter_group_arn" {
+  description = "The AWS ARN associated with the parameter group"
+  value       = module.elasticache.parameter_group_arn
+}
+
+output "parameter_group_id" {
+  description = "The ElastiCache parameter group name"
+  value       = module.elasticache.parameter_group_id
+}
+
+################################################################################
+# Subnet Group
+################################################################################
+
+output "subnet_group_name" {
+  description = "The ElastiCache subnet group name"
+  value       = module.elasticache.subnet_group_name
+}
+
+################################################################################
+# Security Group
+################################################################################
+
+output "security_group_arn" {
+  description = "Amazon Resource Name (ARN) of the security group"
+  value       = module.elasticache.security_group_arn
+}
+
+output "security_group_id" {
+  description = "ID of the security group"
+  value       = module.elasticache.security_group_id
+}

--- a/examples/redis-replication-group-with-cluster-replica/versions.tf
+++ b/examples/redis-replication-group-with-cluster-replica/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.47"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -20,13 +20,13 @@ resource "aws_elasticache_cluster" "this" {
   availability_zone          = var.availability_zone
   az_mode                    = local.in_replication_group ? null : var.az_mode
   cluster_id                 = var.cluster_id
-  engine                     = var.engine
+  engine                     = local.in_replication_group ? null : var.engine
   engine_version             = local.in_replication_group ? null : var.engine_version
   final_snapshot_identifier  = var.final_snapshot_identifier
   ip_discovery               = var.ip_discovery
 
   dynamic "log_delivery_configuration" {
-    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine != "memcached" }
+    for_each = { for k, v in var.log_delivery_configuration : k => v if var.engine != "memcached" && !local.in_replication_group }
 
     content {
       destination      = try(log_delivery_configuration.value.create_cloudwatch_log_group, true) && log_delivery_configuration.value.destination_type == "cloudwatch-logs" ? aws_cloudwatch_log_group.this[log_delivery_configuration.key].name : log_delivery_configuration.value.destination


### PR DESCRIPTION
## Description
`replication_group_id` conflicts with `engine`. 
`log_delivery_configuration` in `aws_elasticache_cluster` should not be set if `replication_group_id` is set since cluster is being added to a replication group which can have its own `log_delivery_configuration`. Produces error like `InvalidParameterCombination: Cannot specify additional cache cluster parameters when creating a replica cluster.`

## Motivation and Context
Related to:
- Resolves #6
- Resolves #9

https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.CreatingReplGroup.ExistingCluster.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#redis-cluster-mode-disabled-read-replica-instance
https://github.com/hashicorp/terraform-provider-aws/blob/0452bb53c686a9ac565febcc6d0ce02da18a0d8d/internal/service/elasticache/cluster.go#L143
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#engine

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
