### PR TITLE
fix: Remove dots from inter_parameter_group_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,7 @@ resource "random_id" "this" {
 }
 
 locals {
-  inter_parameter_group_name  = "${try(coalesce(var.cluster_id, var.replication_group_id), "")}-${var.parameter_group_family}-${try(random_id.this[0].hex, "")}"
+  inter_parameter_group_name  = "${try(coalesce(var.cluster_id, var.replication_group_id), "")}-${replace(var.parameter_group_family, ".", "")}-${try(random_id.this[0].hex, "")}"
   parameter_group_name        = coalesce(var.parameter_group_name, local.inter_parameter_group_name)
   parameter_group_name_result = var.create && var.create_parameter_group ? aws_elasticache_parameter_group.this[0].id : var.parameter_group_name
 

--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,7 @@ resource "random_id" "this" {
 }
 
 locals {
-  inter_parameter_group_name  = "${try(coalesce(var.cluster_id, var.replication_group_id), "")}-${replace(var.parameter_group_family, ".", "")}-${try(random_id.this[0].hex, "")}"
+  inter_parameter_group_name  = "${try(coalesce(var.cluster_id, var.replication_group_id), "")}-${replace(var.parameter_group_family, ".", "-")}-${try(random_id.this[0].hex, "")}"
   parameter_group_name        = coalesce(var.parameter_group_name, local.inter_parameter_group_name)
   parameter_group_name_result = var.create && var.create_parameter_group ? aws_elasticache_parameter_group.this[0].id : var.parameter_group_name
 


### PR DESCRIPTION
## Description

Fix an internal local name used to create a Parameter Group Family. Current module breaks when using older families and no declared family name, because old names contain dots in the name and this is not allowed for Parameter Group Family names.


## Motivation and Context
Module can't create an internal parameter group name when using older families. 

Parameter group families do not follow a very strict naming convention in AWS. There are situations like the following: 
(https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html)

|Redis OSS Version|Family name|
|---|---|
|7 (current)|redis7|
|6|redis6.x|
|5|redis5.0|


Also, AWS enforces naming rules for parameter family creation. Notably, item no.5 declares: 
(https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Creating.html)

> Parameter group naming constraints are as follows:
> * Must begin with an ASCII letter.
> * **Can only contain ASCII letters, digits, and hyphens.**

So when using the module to create an ElastiCache cluster without a custom name, we get the following error: 
```
  Error: creating ElastiCache Parameter Group (redis-dev-redis6.x-ec5a4b07c01ecf4a):
operation error ElastiCache: CreateCacheParameterGroup, https response error StatusCode: 400, 
RequestID: ****, InvalidParameterValue: The parameter CacheParameterGroupName is not a valid identifier. 
Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens;
and must not end with a hyphen or contain two consecutive hyphens.
```


## Breaking Changes

No breaking changes

## How Has This Been Tested?
- [x] `N/A` I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
