### PR TITLE
Fix cache_usage_limits issue when empty map (default value) is provided.

### DIFF
--- a/modules/serverless-cache/main.tf
+++ b/modules/serverless-cache/main.tf
@@ -5,7 +5,7 @@ resource "aws_elasticache_serverless_cache" "this" {
   name   = var.cache_name
 
   dynamic "cache_usage_limits" {
-    for_each = try([var.cache_usage_limits], [])
+    for_each = length(var.cache_usage_limits) > 0 ? [var.cache_usage_limits] : []
     content {
 
       dynamic "data_storage" {


### PR DESCRIPTION
There is a bug in terraform provider which causes issues when deploying empty cache_usage_limits block (described here: https://github.com/hashicorp/terraform-provider-aws/issues/36374), passing empty map in var.cache_usage_limits as [var.cache_usage_limits] generates list with one element [ null, ] which causes terraform to pass empty cache_usage_limits hence triggers provider bug.

## Description
Passing empty map in var.cache_usage_limits as [var.cache_usage_limits] generates list with one element [ null, ] which causes terraform to pass empty cache_usage_limits

## Motivation and Context
There is a bug in terraform provider which causes issues when deploying empty cache_usage_limits block (described here: https://github.com/hashicorp/terraform-provider-aws/issues/36374), passing empty map in var.cache_usage_limits as [var.cache_usage_limits] generates list with one element [ null, ] which causes terraform to pass empty cache_usage_limits hence triggers provider bug.

## Breaking Changes
None.

## How Has This Been Tested?
Applied changes with updated module code.