### PR TITLE
feat: Change `apply_immediately` default value to `false`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,9 +21,9 @@ variable "create_cluster" {
 }
 
 variable "apply_immediately" {
-  description = "Whether any database modifications are applied immediately, or during the next maintenance window. Default is `false`"
+  description = "Whether any database modifications are applied immediately, or during the next maintenance window"
   type        = bool
-  default     = null
+  default     = false
 }
 
 variable "auto_minor_version_upgrade" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context

The description for the `apply_immediately` variable states that the default value is `false`, despite the fact that it is set to `null`, which is somewhat misleading. Other modules with similar functionality have the default value for this variable set to `false`: 

https://github.com/terraform-aws-modules/terraform-aws-rds/blob/master/variables.tf#L283-L287

## Breaking Changes

This PR should not cause any breaking changes because the default value for `apply_immediately` at the resource level is `false`:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#apply_immediately-1

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
