### PR TITLE
feat: Set `create_before_destroy` on subnet group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -286,6 +286,10 @@ resource "aws_elasticache_subnet_group" "this" {
   subnet_ids  = var.subnet_ids
 
   tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added 
```
lifecycle {
    create_before_destroy = true
  }
```
to `aws_elasticache_subnet_group.this`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tried to rename a subnet_group (because I changed the redis name) and it fails to delete, because it was in-use.
Error:
```
│ Error: deleting ElastiCache Subnet Group (testing-c3d280ab-2765-b1e7-5be0-bf71f8e80960): operation error ElastiCache: DeleteCacheSubnetGroup, https response error StatusCode: 400, RequestID: b891773d-fc27-40a5-8c77-3af7ecbe6442, CacheSubnetGroupInUse: Cache subnet group testing-c3d280ab-2765-b1e7-5be0-bf71f8e80960 is currently in use by a cache cluster.
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
