### PR TITLE
fix: Enable transit mode encryption var as it is now available in redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC Subnet IDs for the Elasticache subnet group | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting cluster resource | `map(string)` | `{}` | no |
-| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Enable encryption in-transit. Supported only with Memcached versions `1.6.12` and later, running in a VPC | `bool` | `true` | no |
+| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Enable encryption in-transit. | `bool` | `null` | no |
 | <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are preferred and required | `string` | `null` | no |
 | <a name="input_user_group_ids"></a> [user\_group\_ids](#input\_user\_group\_ids) | User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid | `list(string)` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Identifier of the VPC where the security group will be created | `string` | `null` | no |

--- a/examples/redis-replication-group/main.tf
+++ b/examples/redis-replication-group/main.tf
@@ -64,7 +64,7 @@ module "elasticache" {
 
   # enable encryption in-transit
   transit_encryption_enabled = true
-  transit_encryption_mode    = "preferred"
+  transit_encryption_mode    = "required"
 
   tags = local.tags
 }

--- a/examples/redis-replication-group/main.tf
+++ b/examples/redis-replication-group/main.tf
@@ -30,10 +30,9 @@ module "elasticache" {
   engine_version = "7.1"
   node_type      = "cache.t4g.small"
 
-  transit_encryption_enabled = true
-  auth_token                 = "PickSomethingMoreSecure123!"
-  maintenance_window         = "sun:05:00-sun:09:00"
-  apply_immediately          = true
+  auth_token         = "PickSomethingMoreSecure123!"
+  maintenance_window = "sun:05:00-sun:09:00"
+  apply_immediately  = true
 
   # Security Group
   vpc_id = module.vpc.vpc_id
@@ -62,6 +61,10 @@ module "elasticache" {
       value = "yes"
     }
   ]
+
+  # enable encryption in-transit
+  transit_encryption_enabled = true
+  transit_encryption_mode    = "preferred"
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,8 @@ resource "aws_elasticache_cluster" "this" {
   snapshot_retention_limit     = local.in_replication_group ? null : var.snapshot_retention_limit
   snapshot_window              = local.in_replication_group ? null : var.snapshot_window
   subnet_group_name            = local.in_replication_group ? null : local.subnet_group_name
-  transit_encryption_enabled   = var.engine == "memcached" ? var.transit_encryption_enabled : null
+  # this makes it so that the transit encryption is enabled by default for memcached, which prevents a backwards incompatible change
+  transit_encryption_enabled   = var.engine == "memcached" ? true : var.transit_encryption_enabled
 
   tags = local.tags
 

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_elasticache_cluster" "this" {
   snapshot_window              = local.in_replication_group ? null : var.snapshot_window
   subnet_group_name            = local.in_replication_group ? null : local.subnet_group_name
   # this makes it so that the transit encryption is enabled by default for memcached, which prevents a backwards incompatible change
-  transit_encryption_enabled   = var.engine == "memcached" ? true : var.transit_encryption_enabled
+  transit_encryption_enabled = var.engine == "memcached" ? true : var.transit_encryption_enabled
 
   tags = local.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -176,9 +176,9 @@ variable "snapshot_window" {
 }
 
 variable "transit_encryption_enabled" {
-  description = "Enable encryption in-transit. Supported only with Memcached versions `1.6.12` and later, running in a VPC"
+  description = "Enable encryption in-transit."
   type        = bool
-  default     = true
+  default     = null
 }
 
 variable "transit_encryption_mode" {


### PR DESCRIPTION
## Description

This allows you to set transit mode encryption for instances other than memcached, but retains the existing behavior of setting it to true for memcached by default.

## Motivation and Context

I want to beable to set this for redis, which i currently cannot. If you cant set this, you can't create users, so you need to be able to set this.

## Breaking Changes
None, see comment and above.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
