### PR TITLE
fix: Append ElastiCache log type to CW log group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,7 @@ locals {
 resource "aws_cloudwatch_log_group" "this" {
   for_each = { for k, v in var.log_delivery_configuration : k => v if local.create_cloudwatch_log_group && try(v.create_cloudwatch_log_group, true) && try(v.destination_type, "") == "cloudwatch-logs" }
 
-  name              = "/aws/elasticache/${try(each.value.cloudwatch_log_group_name, coalesce(var.cluster_id, var.replication_group_id), "")}"
+  name              = "/aws/elasticache/${try(each.value.cloudwatch_log_group_name, coalesce(var.cluster_id, var.replication_group_id), "")/${each.key}}"
   retention_in_days = try(each.value.cloudwatch_log_group_retention_in_days, 14)
   kms_key_id        = try(each.value.cloudwatch_log_group_kms_key_id, null)
   skip_destroy      = try(each.value.cloudwatch_log_group_skip_destroy, null)


### PR DESCRIPTION




## Description
Currently, Terraform execution fails when both slow-log and engine-log are enabled simultaneously, resulting in the following name conflict error:

```The specified log group already exists```

This occurs because both logs attempt to use the same CloudWatch Log Group name.

## Motivation and Context
I want to enable both engine-log and slow-log simultaneously but current module doesn't let me do that.


## Example:
Updated `log_delivery_configuration`:

```log_delivery_configuration = {
  slow-log = {
    destination_type = "cloudwatch-logs"
    log_format       = "json"
  }
  engine-log = {
    destination_type = "cloudwatch-logs"
    log_format       = "json"
  }
}
```

## Breaking Changes
None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
