### PR TITLE
feat: Make log_delivery_group input not-nullable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,7 @@ variable "ip_discovery" {
 
 variable "log_delivery_configuration" {
   description = "(Redis OSS or Valkey) Specifies the destination and format of Redis OSS/Valkey SLOWLOG or Redis OSS/Valkey Engine Log"
+  nullable    = false
   type        = any
   default = {
     slow-log = {


### PR DESCRIPTION
This change is created to fix a problem when trying to use this module as DRY code.





## Description

### Problem

The log_delivery_group variable expects a map, which it will turn into the log delivery configuration.

There is a default map provided in this module, which creates the slow-log log group.

  1. Say you create a new root module calling this elasticache submodule. You want to use this same root module for all your environments, and just pass the root module different values to determine what it does in different environments.

  2. You use this new root module to deploy production with the default values here. default slow-log group is created.

  3. You want to deploy non-production with a custom slow-log. So you add an input variable when calling the `module` block, passing in a custom slow-log configuration. the custom slow-log is created.

  4. You go back to deploy production, but there is a problem now. Since your root module is always passing in some input variable to the elasticache submodule, the elasticache submodule's default value is always overridden. The only way to get production to work again is to duplicate the default variable from this elasticache module, into your own root module's variable, as its default.

Now you have to duplicate this module's variable defaults in your root module. Not very DRY, and could cause issues later if the elasticache module changes and now your root module's defaults don't apply anymore.

### Solution

Add `nullable = false` to the elasticache module's input variable. This prevents you from passing in a null value to the input. If you pass in a null, Terraform will simply ignore the input as if it was never passed.

Terraform can't use a null as the value anyway; it dies saying it expects a map value, not a null.

So this doesn't break any existing functionality, but it does allow a root module to pass a default `null` value for this input variable, which makes the elasticache module use its default value.

Now you can use one DRY module, and decide to use the module's default variables or not, by passing null, or something else.

## Motivation and Context

Getting a root module to pass input value sometimes, or pass `null` to use submodule's default value.

Context is wanting to customize the log group for non-prod, but use only defaults for prod.

## Breaking Changes

None

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
