### PR TITLE
fix: Remove restriction on engine to allow Valkey cluster creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,11 +2,6 @@ locals {
   # https://github.com/hashicorp/terraform-provider-aws/blob/3c4cb52c5dc2c09e10e5a717f73d1d8bc4186e87/internal/service/elasticache/cluster.go#L271
   in_replication_group = var.replication_group_id != null
 
-  # elasticache clusters currently do not support engine type valkey
-  # TODO: remove this local `create_cluster` conditional once this bug is addressed:
-  # https://github.com/hashicorp/terraform-provider-aws/issues/39905
-  create_cluster = var.create_cluster && var.engine != "valkey" ? true : false
-
   security_group_ids = local.create_security_group ? concat(var.security_group_ids, [aws_security_group.this[0].id]) : var.security_group_ids
   port               = var.engine == "memcached" ? 11211 : 6379
 
@@ -18,7 +13,7 @@ locals {
 ################################################################################
 
 resource "aws_elasticache_cluster" "this" {
-  count = var.create && local.create_cluster ? 1 : 0
+  count = var.create && var.create_cluster ? 1 : 0
 
   apply_immediately          = var.apply_immediately
   auto_minor_version_upgrade = var.auto_minor_version_upgrade


### PR DESCRIPTION
## Description

Remove local.create_cluster logic due to fixed provider bug

## Motivation and Context

Bug in provider [fixed in 5.84](https://github.com/hashicorp/terraform-provider-aws/issues/39905), should be working now without local override.
Provider version is already bumped to 5.93, so no update in `required_providers` needed.

 Fixes #43

## Breaking Changes

None

## How Has This Been Tested?

I'm returning here code that was working fine before https://github.com/terraform-aws-modules/terraform-aws-elasticache/pull/26. I'll try to test different scenarios tomorrow to ensure that Valkey works as expected.

- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
