### PR TITLE
fix: Case insensitive matching deprecated

### DIFF
--- a/modules/user-group/main.tf
+++ b/modules/user-group/main.tf
@@ -33,7 +33,7 @@ resource "aws_elasticache_user" "default" {
     }
   }
 
-  engine               = try(var.default_user.engine, "REDIS")
+  engine               = try(var.default_user.engine, "redis")
   no_password_required = try(var.default_user.no_password_required, null)
   passwords            = try(var.default_user.passwords, null)
   user_id              = var.default_user.user_id
@@ -60,7 +60,7 @@ resource "aws_elasticache_user" "this" {
     }
   }
 
-  engine               = try(each.value.engine, "REDIS")
+  engine               = try(each.value.engine, "redis")
   no_password_required = try(each.value.no_password_required, null)
   passwords            = try(each.value.passwords, null)
   user_id              = try(each.value.user_id, each.key)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Case insensitive matching has been deprecated on `elasticache_user` resource

## Breaking Changes

This should not be a breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
