### PR TITLE
fix: User needs to be a sensitive output or it will cause failures in strict mode

### DIFF
--- a/modules/user-group/outputs.tf
+++ b/modules/user-group/outputs.tf
@@ -19,4 +19,5 @@ output "group_id" {
 output "users" {
   description = "A map of users created and their attributes"
   value       = aws_elasticache_user.this
+  sensitive   = true
 }


### PR DESCRIPTION



## Description
The user-group submodule has user as an output and it is not set to sensitive. This is a requirement for running terraform in strict mode as it is a sensitive value. This blocks the module being used in openTofu which by default requires sensitive outputs to be labelled as such.

## Motivation and Context
This is a requirement for running terraform in strict mode as it is a sensitive value. This blocks the module being used in openTofu which by default requires sensitive outputs to be labelled as such.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.
## How Has This Been Tested?
I am running this module in my own project and no changes occur, it now can be run on OpenTofu
