### PR TITLE
feat: Add replication group port to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.12.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.93 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.93 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.12.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
 
 ## Modules
 
@@ -492,6 +492,7 @@ No modules.
 | <a name="output_replication_group_engine_version_actual"></a> [replication\_group\_engine\_version\_actual](#output\_replication\_group\_engine\_version\_actual) | Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine |
 | <a name="output_replication_group_id"></a> [replication\_group\_id](#output\_replication\_group\_id) | ID of the ElastiCache Replication Group |
 | <a name="output_replication_group_member_clusters"></a> [replication\_group\_member\_clusters](#output\_replication\_group\_member\_clusters) | Identifiers of all the nodes that are part of this replication group |
+| <a name="output_replication_group_port"></a> [replication\_group\_port](#output\_replication\_group\_port) | Port of the primary node in the replication group, if the cluster mode is disabled |
 | <a name="output_replication_group_primary_endpoint_address"></a> [replication\_group\_primary\_endpoint\_address](#output\_replication\_group\_primary\_endpoint\_address) | Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled |
 | <a name="output_replication_group_reader_endpoint_address"></a> [replication\_group\_reader\_endpoint\_address](#output\_replication\_group\_reader\_endpoint\_address) | Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |

--- a/examples/redis-global-replication-group/README.md
+++ b/examples/redis-global-replication-group/README.md
@@ -74,6 +74,7 @@ No inputs.
 | <a name="output_replication_group_engine_version_actual"></a> [replication\_group\_engine\_version\_actual](#output\_replication\_group\_engine\_version\_actual) | Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine |
 | <a name="output_replication_group_id"></a> [replication\_group\_id](#output\_replication\_group\_id) | ID of the ElastiCache Replication Group |
 | <a name="output_replication_group_member_clusters"></a> [replication\_group\_member\_clusters](#output\_replication\_group\_member\_clusters) | Identifiers of all the nodes that are part of this replication group |
+| <a name="output_replication_group_port"></a> [replication\_group\_port](#output\_replication\_group\_port) | Port of the primary node in the replication group, if the cluster mode is disabled |
 | <a name="output_replication_group_primary_endpoint_address"></a> [replication\_group\_primary\_endpoint\_address](#output\_replication\_group\_primary\_endpoint\_address) | Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled |
 | <a name="output_replication_group_reader_endpoint_address"></a> [replication\_group\_reader\_endpoint\_address](#output\_replication\_group\_reader\_endpoint\_address) | Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |

--- a/examples/redis-global-replication-group/outputs.tf
+++ b/examples/redis-global-replication-group/outputs.tf
@@ -61,6 +61,11 @@ output "replication_group_primary_endpoint_address" {
   value       = module.elasticache_primary.replication_group_primary_endpoint_address
 }
 
+output "replication_group_port" {
+  description = "Port of the primary node in the replication group, if the cluster mode is disabled"
+  value       = module.elasticache_primary.replication_group_port
+}
+
 output "replication_group_reader_endpoint_address" {
   description = "Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled"
   value       = module.elasticache_primary.replication_group_reader_endpoint_address

--- a/examples/redis-replication-group/README.md
+++ b/examples/redis-replication-group/README.md
@@ -66,6 +66,7 @@ No inputs.
 | <a name="output_replication_group_engine_version_actual"></a> [replication\_group\_engine\_version\_actual](#output\_replication\_group\_engine\_version\_actual) | Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine |
 | <a name="output_replication_group_id"></a> [replication\_group\_id](#output\_replication\_group\_id) | ID of the ElastiCache Replication Group |
 | <a name="output_replication_group_member_clusters"></a> [replication\_group\_member\_clusters](#output\_replication\_group\_member\_clusters) | Identifiers of all the nodes that are part of this replication group |
+| <a name="output_replication_group_port"></a> [replication\_group\_port](#output\_replication\_group\_port) | Port of the primary node in the replication group, if the cluster mode is disabled |
 | <a name="output_replication_group_primary_endpoint_address"></a> [replication\_group\_primary\_endpoint\_address](#output\_replication\_group\_primary\_endpoint\_address) | Address of the endpoint for the primary node in the replication group, if the cluster mode is disabled |
 | <a name="output_replication_group_reader_endpoint_address"></a> [replication\_group\_reader\_endpoint\_address](#output\_replication\_group\_reader\_endpoint\_address) | Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | Amazon Resource Name (ARN) of the security group |

--- a/examples/redis-replication-group/outputs.tf
+++ b/examples/redis-replication-group/outputs.tf
@@ -61,6 +61,11 @@ output "replication_group_primary_endpoint_address" {
   value       = module.elasticache.replication_group_primary_endpoint_address
 }
 
+output "replication_group_port" {
+  description = "Port of the primary node in the replication group, if the cluster mode is disabled"
+  value       = module.elasticache.replication_group_port
+}
+
 output "replication_group_reader_endpoint_address" {
   description = "Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled"
   value       = module.elasticache.replication_group_reader_endpoint_address

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,6 +61,11 @@ output "replication_group_primary_endpoint_address" {
   value       = try(aws_elasticache_replication_group.this[0].primary_endpoint_address, aws_elasticache_replication_group.global[0].primary_endpoint_address, null)
 }
 
+output "replication_group_port" {
+  description = "Port of the primary node in the replication group, if the cluster mode is disabled"
+  value       = try(aws_elasticache_replication_group.this[0].port, aws_elasticache_replication_group.global[0].port, null)
+}
+
 output "replication_group_reader_endpoint_address" {
   description = "Address of the endpoint for the reader node in the replication group, if the cluster mode is disabled"
   value       = try(aws_elasticache_replication_group.this[0].reader_endpoint_address, aws_elasticache_replication_group.global[0].reader_endpoint_address, null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Define replicaiton group port as output

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I need to get the port of the replication group

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
