### PR TITLE
feat: Allow security group rules to reference the security group created by the module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.5
+    rev: v1.100.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_workspace_remote'
       - id: terraform_validate
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -44,6 +44,11 @@ module "elasticache" {
       description = "VPC traffic"
       cidr_ipv4   = module.vpc.vpc_cidr_block
     }
+    ingress-self-redis = {
+      type = "ingress"
+      referenced_security_group_id = "self"
+      description = "Allow traffic from this security group to itself."
+    }
   }
 
   # Subnet Group

--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -38,12 +38,6 @@ module "elasticache" {
   # Security Group
   vpc_id = module.vpc.vpc_id
   security_group_rules = {
-    ingress_vpc = {
-      # Default type is `ingress`
-      # Default port is based on the default engine port
-      description = "VPC traffic"
-      cidr_ipv4   = module.vpc.vpc_cidr_block
-    }
     ingress-self-redis = {
       type = "ingress"
       referenced_security_group_id = "self"

--- a/examples/redis-cluster/main.tf
+++ b/examples/redis-cluster/main.tf
@@ -39,9 +39,9 @@ module "elasticache" {
   vpc_id = module.vpc.vpc_id
   security_group_rules = {
     ingress-self-redis = {
-      type = "ingress"
+      type                         = "ingress"
       referenced_security_group_id = "self"
-      description = "Allow traffic from this security group to itself."
+      description                  = "Allow traffic from this security group to itself."
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -330,7 +330,7 @@ resource "aws_vpc_security_group_ingress_rule" "this" {
   description                  = try(each.value.description, null)
   from_port                    = try(each.value.from_port, local.port)
   prefix_list_id               = lookup(each.value, "prefix_list_id", null)
-  referenced_security_group_id = lookup(each.value, "referenced_security_group_id", null)
+  referenced_security_group_id = lookup(each.value, "referenced_security_group_id", null) == "self" ? aws_security_group.this[0].id : lookup(each.value, "referenced_security_group_id", null)
   to_port                      = try(each.value.to_port, local.port)
 
   tags = merge(local.tags, var.security_group_tags, try(each.value.tags, {}))
@@ -349,7 +349,7 @@ resource "aws_vpc_security_group_egress_rule" "this" {
   description                  = try(each.value.description, null)
   from_port                    = try(each.value.from_port, null)
   prefix_list_id               = lookup(each.value, "prefix_list_id", null)
-  referenced_security_group_id = lookup(each.value, "referenced_security_group_id", null)
+  referenced_security_group_id = lookup(each.value, "referenced_security_group_id", null) == "self" ? aws_security_group.this[0].id : lookup(each.value, "referenced_security_group_id", null)
   to_port                      = try(each.value.to_port, null)
 
   tags = merge(local.tags, var.security_group_tags, try(each.value.tags, {}))


### PR DESCRIPTION
## Description
In the security group created by this module, allow rules to reference this security group itself as the source, in a manner similar to the `self = true` argument for the older `aws_security_group_rule` resource type.
This is done by introducing the special value "self" for the `referenced_security_group_id` of the SG rule resource. When this value is used, then `referenced_security_group_id` receives as a value the ID of the security group created by this module.

```
  security_group_rules = {
    ingress-self-redis = {
      type = "ingress"
      referenced_security_group_id = "self"
      description = "Allow traffic from this security group to itself."
    }
  }
```

## Motivation and Context
`aws_vpc_security_group_ingress_rule` and its egress companion do not have a `self` argument. This is reflected in the way this module is written.
For clusters in general, it is a good idea to allow intra-cluster communication by default, for reasons such as replication, etc.
We have "self" type rules for the SGs of all clusters.

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
