### PR TITLE
fix: Revert - Enable `transit_encryption_enabled` for all avialble engines now that Elasticache supports this #56

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.100.1
+    rev: v1.101.0
     hooks:
       - id: terraform_fmt
       - id: terraform_wrapper_module_for_each

--- a/README.md
+++ b/README.md
@@ -464,8 +464,8 @@ No modules.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC Subnet IDs for the Elasticache subnet group | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for creating, updating, and deleting cluster resource | `map(string)` | `{}` | no |
-| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Enable encryption in-transit. Supported on replication groups running Valkey 7.2 and later, and Redis OSS versions 3.2.6, 4.0.10 and later, running in a VPC | `bool` | `true` | no |
-| <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are preferred and required | `string` | `null` | no |
+| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Enable encryption in-transit | `bool` | `true` | no |
+| <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are `preferred` and `required` | `string` | `null` | no |
 | <a name="input_user_group_ids"></a> [user\_group\_ids](#input\_user\_group\_ids) | User Group ID to associate with the replication group. Only a maximum of one (1) user group ID is valid | `list(string)` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Identifier of the VPC where the security group will be created | `string` | `null` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,8 @@ resource "aws_elasticache_cluster" "this" {
   snapshot_retention_limit     = local.in_replication_group ? null : var.snapshot_retention_limit
   snapshot_window              = local.in_replication_group ? null : var.snapshot_window
   subnet_group_name            = local.in_replication_group ? null : local.subnet_group_name
-  transit_encryption_enabled   = var.transit_encryption_enabled
+  # ToDo - remove restriction at next breaking change https://github.com/terraform-aws-modules/terraform-aws-elasticache/pull/56
+  transit_encryption_enabled = var.engine == "memcached" ? var.transit_encryption_enabled : null
 
   tags = local.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -176,13 +176,13 @@ variable "snapshot_window" {
 }
 
 variable "transit_encryption_enabled" {
-  description = "Enable encryption in-transit. Supported on replication groups running Valkey 7.2 and later, and Redis OSS versions 3.2.6, 4.0.10 and later, running in a VPC"
+  description = "Enable encryption in-transit"
   type        = bool
   default     = true
 }
 
 variable "transit_encryption_mode" {
-  description = "A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are preferred and required"
+  description = "A setting that enables clients to migrate to in-transit encryption with no downtime. Valid values are `preferred` and `required`"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Description
- Revert - Enable `transit_encryption_enabled` for all avialble engines now that Elasticache supports this #56

## Motivation and Context
- Causes resource disruption due to existing defaults https://github.com/terraform-aws-modules/terraform-aws-elasticache/pull/56#issuecomment-3378746089

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
