### PR TITLE
expose the cluster_id attribute on the module output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,11 @@
 # Cluster
 ################################################################################
 
+output "cluster_id" {
+  description = "The ID of the ElastiCache Cluster"
+  value       = try(aws_elasticache_cluster.this[0].id, null)
+}
+
 output "cluster_arn" {
   description = "The ARN of the ElastiCache Cluster"
   value       = try(aws_elasticache_cluster.this[0].arn, null)


### PR DESCRIPTION
## Description
The `cluster_id` attribute is now part of the module output.

## Motivation and Context
The module only had `cluster_arn`. If you needed the ID in a dependency, you could extract it from the ARN, but it's an unnecessary complication in your code.
This solution is simple and elegant, it keeps the user code simple.

## Breaking Changes
No.

## How Has This Been Tested?
It's a very trivial change, just run apply then look at the output.